### PR TITLE
Fix for multi select custom fields when saving

### DIFF
--- a/lib/amorail/entity/params.rb
+++ b/lib/amorail/entity/params.rb
@@ -17,11 +17,10 @@ module Amorail # :nodoc: all
       props = properties.send(self.class.amo_name)
 
       custom_fields = []
-
-      self.class.properties.each do |k, v|
+      self.class.properties.each do |k, value|
         prop_id = props.send(k).id
-        prop_val = { value: send(k) }.merge(v)
-        custom_fields << { id: prop_id, values: [prop_val] }
+        prop_val = props.send(k)['type_id'] == "5" ? [send(k)] : { value: send(k) }.merge(value)
+        custom_fields << { id: prop_id, values: [prop_val].flatten }
       end
 
       custom_fields
@@ -41,7 +40,10 @@ module Amorail # :nodoc: all
 
     def normalize_custom_fields(val)
       val.reject do |field|
-        field[:values].all? { |item| !item[:value] }
+	next if field[:values].instance_of? Array
+        field[:values].all? { |item| 
+	   !item[:value]
+	}
       end
     end
 


### PR DESCRIPTION
For a multi_select custom_field type, amoCRM demands to be a direct array 

```
[
   "id"=>692250,       //field id
   "values"=> [1662884,1662886]    //Field of multiselect type (an array of values is allowed)
],
```

instead of 

```
[
  "id"=>691606,       //field id
  "values"=> [
    [
      "value"=>1519210  //Field of list type, enum parameter value is assigned to the field value
    ]
  ]
]
```

The multi select fields were not being stored from the beginning or when updated. This commit changes the way it's sent and fixes that
